### PR TITLE
Publish release to PyPI

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -52,3 +53,6 @@ jobs:
             gh release upload ${{ github.ref_name }} dist/*
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Publish distribution files to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
New PyPI trusted publishing with GitHub Actions.
