### PR TITLE
Fix pylint possibly-used-before-assignment

### DIFF
--- a/linkcheck_gui/library/bookmarks/firefox.py
+++ b/linkcheck_gui/library/bookmarks/firefox.py
@@ -20,6 +20,7 @@ import glob
 
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
+    # pylint: disable=possibly-used-before-assignment
     if os.name == "nt":
         basedir = os.environ["APPDATA"]
         dirpath = os.path.join(basedir, "Mozilla", "Firefox", "Profiles")

--- a/linkcheck_gui/library/bookmarks/opera.py
+++ b/linkcheck_gui/library/bookmarks/opera.py
@@ -25,6 +25,7 @@ OperaBookmarkFiles = (
 
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
+    # pylint: disable=possibly-used-before-assignment
     if os.name == "nt":
         basedir = os.environ["APPDATA"]
         dirpath = os.path.join(basedir, "Opera", "Opera")


### PR DESCRIPTION
```
************* Module linkcheck_gui.library.bookmarks.opera
linkcheck_gui/library/bookmarks/opera.py:33:11: E0606: Possibly using variable 'dirpath' before assignment (possibly-used-before-assignment)
************* Module linkcheck_gui.library.bookmarks.firefox
linkcheck_gui/library/bookmarks/firefox.py:28:11: E0606: Possibly using variable 'dirpath' before assignment (possibly-used-before-assignment)
```
